### PR TITLE
Make installer path-independant

### DIFF
--- a/neoCodeInstaller/src/main.rs
+++ b/neoCodeInstaller/src/main.rs
@@ -32,8 +32,8 @@ fn main() {
     let testing = args.testing;
     let deps = args.deps;
 
-    let starting_dir: PathBuf = match env::current_dir() {
-        Ok(val) => val,
+    let starting_dir: PathBuf = match env::current_exe() {
+        Ok(val) => val.parent().unwrap().to_path_buf(),
         Err(_err) => PathBuf::new(),
     };
 


### PR DESCRIPTION
Ideally one would embed the required files in the installer, but at least for now this should prevent any further head-scratching like mine yesterday.
PS: Don't know much about rust so maybe there's a better way!