### PR TITLE
Allow macos compilation and bump binary

### DIFF
--- a/neoCodeInstaller/src/helpers.rs
+++ b/neoCodeInstaller/src/helpers.rs
@@ -346,6 +346,11 @@ pub mod funcs {
         }
     }
 
+    // Currently empty, allows compilation on macos.
+    #[cfg(target_os = "macos")]
+    pub fn check_dependencies() {
+    }
+
     // Check for dependencies for windows
     #[cfg(target_os = "windows")]
     pub fn check_dependencies() {


### PR DESCRIPTION
Following from https://github.com/Sewdohe/nvim-config/pull/7

After pulling the latest main I had to make these changes to allow compilation on mac.
Maybe this could be expanded if more tools are needed on this os?

Also, before merging maybe @brukberhane could try this binary as well? 